### PR TITLE
Change startup trigger to logon to prevent issues, remove unnecessary capital letters, add example launch arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Set general settings.
 
 ![Chapter 6 p1_LI](https://user-images.githubusercontent.com/106172193/170519308-df13b85a-00c8-4e57-ad12-6d9b118ed1ac.jpg)
 
-Create the Trigger for system startup.
+Create the Trigger for login. Triggers set to startup don't seem to work at all. It's best to set it to trigger on a specific user's login, as in the event of an unstable curve, you could log in as another user and remove or edit the task.
 
-![Chapter 6 p2](https://user-images.githubusercontent.com/106172193/170519471-b033ca84-48ea-4822-88a4-a9daecc33b7f.png)
+![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/468e8006-fbf3-48eb-92f6-2265aed3010c)
 
 Create the Trigger for wakeup.
 

--- a/README.md
+++ b/README.md
@@ -20,67 +20,67 @@ We are using PBO2 tuner to set an OC curve (AMD curve optimizer)
 
 # 2) Why are we doing it? What are the Benefits?
 Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or use PBO in their Bios to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
-With this Guide, you will at least be able to tweak Things a little inside of Windows for potentially better Thermals and Clockspeeds that stay longer and more often at the highest they can be.
+With this guide, you will at least be able to tweak things a little inside of Windows for potentially better thermals and clockspeeds that stay longer and more often at the highest they can be.
 
 # 3) Options on what we can do
-Set PBO OC Curve manually after every change in Windows powerstate
+Set PBO OC curve manually after every change in Windows powerstate
      
-Set PBO OC Curve automatically with every system boot/restart/wakeup (means after every change in Windows powerstate)
+Set PBO OC curve automatically with every system boot/restart/wakeup (means after every change in Windows powerstate)
      
-**Optional** possibility to create custom BurnedToast Alert whenever the CO Curve has been set automatically. This way, you will always have the assurance that it actually applied.
+**Optional** possibility to create custom BurnedToast alert whenever the CO curve has been set automatically. This way, you will always have the assurance that it actually applied.
     
 # 4) What do we need?
 [Debug-cli.7zp](https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/page-45#post-28999750) from PJVol from Overclocker.net thread
 
-Monitoring software to confirm CO Curve has been set([HwInfo](https://www.hwinfo.com/download/) or [RyzenMaster](https://www.amd.com/en/technologies/ryzen-master))
+Monitoring software to confirm CO curve has been set([HwInfo](https://www.hwinfo.com/download/) or [RyzenMaster](https://www.amd.com/en/technologies/ryzen-master))
 
-BurntToast Module in PowerShell
+BurntToast module in PowerShell
 
-Allow Execution Policies change in PowerShell
+Allow execution policies change in PowerShell
 
-PowerShell script for BurntToast Alert
+PowerShell script for BurntToast alert
 
-Any PNG of your Choice for the Alert
+Any PNG of your choice for the alert
 
 # 5) How to set PBO2 Tuner manually
 First download [Debug-cli.7zp](https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/page-45#post-28999750).
 
-Get a Monitoring Software like [HwInfo](https://www.hwinfo.com/download/) or [RyzenMaster](https://www.amd.com/en/technologies/ryzen-master). You will need this to see your CPU Voltage and Temperature and to later confirm that your Settings work.
+Get monitoring software like [HwInfo](https://www.hwinfo.com/download/) or [RyzenMaster](https://www.amd.com/en/technologies/ryzen-master). You will need this to see your CPU voltage and temperature and to later confirm that your settings work.
 
-Run a CPU Stress Test like OCCT or Benchmark like Cinebench R20/R23 to push your CPU to ~100% Utilization. See how high your CPU boosts and what Temperatures you get before any changes to it.
+Run a CPU stress test like OCCT or benchmark like Cinebench R20/R23 to push your CPU to ~100% Utilization. See how high your CPU boosts and what temperatures you get before any changes to it.
 
-Now open PBO2 Tuner.exe from the Folder we just downloaded and select the Curve tab
+Now open PBO2 Tuner.exe from the folder we just downloaded and select the curve tab
 
-Start by setting a low negative offset like -10 and decrease it in decrements of -5 to a Minimum of -30.
+Start by setting a low negative offset like -10 and decrease it in decrements of -5 to a minimum of -30.
 
 Make sure to stress test it each step to see if it is stable.
 
 Now you're done! But remember, you will have to do this again every time you restart or wake from sleep.
 
-# 6) How to set PBO2 Tuner automatically with every System boot/restart/wakeup
-Do all the Steps in [Chapter 5](#5-how-to-set-pbo2-tuner-manually) until you're satisfied with the offsets you can get.
+# 6) How to set PBO2 Tuner automatically with every system boot/restart/wakeup
+Do all the steps in [Chapter 5](#5-how-to-set-pbo2-tuner-manually) until you're satisfied with the offsets you can get.
 
-Now Open Windows Task Scheduler. Go to Actions and Create Task.
+Now open Windows Task Scheduler. Go to Actions and Create Task.
 
 **Use the provided Screenshots to configure the Task correctly.**
 
-Set General Settings.
+Set general settings.
 
 ![Chapter 6 p1_LI](https://user-images.githubusercontent.com/106172193/170519308-df13b85a-00c8-4e57-ad12-6d9b118ed1ac.jpg)
 
-Create the Trigger for System startup.
+Create the Trigger for system startup.
 
 ![Chapter 6 p2](https://user-images.githubusercontent.com/106172193/170519471-b033ca84-48ea-4822-88a4-a9daecc33b7f.png)
 
-Create the Trigger for Wakeup.
+Create the Trigger for wakeup.
 
 ![Chapter 6 p3](https://user-images.githubusercontent.com/106172193/170519673-90d6766b-6397-4638-a2b8-08c8028839e9.png)
 
-Create the Action for PBO2 tuner.exe to start with the Offsets as Startup arguments.
+Create the Action for PBO2 tuner.exe to start with the offsets as startup arguments.
 
 ![Chapter 6 p4_LI](https://user-images.githubusercontent.com/106172193/170519780-4835e046-82fc-49fe-8a9f-e1ded1144638.jpg)
 
-Set the Conditions and Settings tab.
+Set the Conditions and Settings tabs.
 
 ![Chapter 6 p5](https://user-images.githubusercontent.com/106172193/170519955-8fd6d69b-36ec-4e1c-b7b8-906fda4a28ac.png)
 
@@ -89,18 +89,18 @@ Set the Conditions and Settings tab.
 
 **Make sure to set the path to your PBO2 tuner.exe since it most likely won't be the same as mine.**
 
-**Customize the Arguments to your previously tested Offsets.**
+**Customize the arguments to your previously tested Offsets.**
 
 Click OK to save it. Congratulations, you are done!
 
-# 7) (Optional) How to create a custom Alert for every time your PBO2 Tuner settings have been applied automatically
-If you are as paranoid as me and have the urge to check PBO2 Tuner after every reboot or wakeup to see if your offset has been set, then I have something to ease your Mind. A Custom Alert tied to the Task Scheduler we just created above to inform you that the Task has been executed.
+# 7) (Optional) How to create a custom alert for every time your PBO2 Tuner settings have been applied automatically
+If you are as paranoid as me and have the urge to check PBO2 Tuner after every reboot or wakeup to see if your offset has been set, then I have something to ease your mind. A custom alert tied to the Task Scheduler we just created above to inform you that the task has been executed.
 
 ![Chapter 7 p1](https://user-images.githubusercontent.com/106172193/170520421-a21eec68-2311-4eb7-ad44-d695410b9a1c.png)
 
-Find a Logo and save into the folder with PBO2 tuner.exe in it.
+Find a logo and save into the folder with PBO2 tuner.exe in it.
 
-Open a Text file and paste this into it:
+Open a text file and paste this into it:
 
 ```pwsh
 Import-Module BurntToast;
@@ -108,9 +108,9 @@ $pngPath="C:\Users\REPLACE_THIS_WITH_THE_PATH_TO_THE_PNG_FILE\whatever.png";
 New-BurntToastNotification -Text "PBO Offset has been applied!", 'PBO Offset has been applied!' -AppLogo $pngPath
 ```
 
-Save as `Alert.ps1`, select All Files types and save in the same folder as PBO2 tuner.exe.
+Save as `Alert.ps1`, select All Files and save in the same folder as PBO2 tuner.exe.
 
-Open Windows PowerShell as Administrator and execute this command:
+Open Windows PowerShell as administrator and execute this command:
 
 ```pwsh
 Install-Module -Name BurntToast
@@ -128,11 +128,11 @@ into PowerShell and run the command. Press Y to proceed. This is necessary for `
 
 **DO THIS AT YOUR OWN RISK**, since you're disabling a security feature of windows.
 
-Now Open Task Scheduler again and look for the Task we've created in [Chapter 6](#6-how-to-set-pbo2-tuner-automatically-with-every-system-bootrestartwakeup).
+Now open Task Scheduler again and look for the task we've created in [Chapter 6](#6-how-to-set-pbo2-tuner-automatically-with-every-system-bootrestartwakeup).
 
 Right click it, select Properties, go to Actions and click New.
 
-**Use the provided Screenshot to set up correctly.**
+**Use the provided screenshot to set up correctly.**
 
 ![Chapter 7 p2_LI](https://user-images.githubusercontent.com/106172193/170520568-ed331286-d0be-4b65-9539-7949ad0334ce.jpg)
 
@@ -142,16 +142,16 @@ Click okay and save all changes.
 
 We're done!
     
-You can test it by right-clicking the Task in Task Scheduler and selecting run.
+You can test it by right-clicking the task in Task Scheduler and selecting run.
 
-# 8) What else can we do to improve CPU Clockspeeds and Thermals?
-Pretty much nothing without the support from AMD and or Motherboard Manufacturers.
+# 8) What else can we do to improve CPU clockspeeds and thermals?
+Pretty much nothing without the support from AMD and or motherboard manufacturers.
 
 Get a better CPU cooler.
 
-(For Enthusiasts with an AIO or Custom Water cooling Block) Get an AM4 Cooler offset bracket(like from DerBauer); reportedly around 5-10 degrees improvement on Core temps
+(For enthusiasts with an AIO or custom water cooling block) Get an AM4 cooler offset bracket (like from DerBauer); reportedly around 5-10 degrees improvement on core temps.
 
-Set higher Baseclock (really not recommended if you don't exactly know what it does and what Problems can be caused by it)
+Set higher Baseclock (really not recommended if you don't exactly know what it does and what problems can be caused by it)
 # 9) Resources used
 - https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Set general settings.
 
 ![Chapter 6 p1_LI](https://user-images.githubusercontent.com/106172193/170519308-df13b85a-00c8-4e57-ad12-6d9b118ed1ac.jpg)
 
-Create the Trigger for login. Triggers set to startup don't seem to work at all. It's best to set it to trigger on a specific user's login, as in the event of an unstable curve, you could log in as another user and remove or edit the task.
+Create the Trigger for login.
+You can set it to All users but it's safer to set it to trigger on a specific user's login, as in the event of an unstable curve on logging in, you could log in as another user and remove or edit the task.
 
-![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/468e8006-fbf3-48eb-92f6-2265aed3010c)
+![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/72f25374-a605-4d6a-bc33-3ea56756dd27)
 
 Create the Trigger for wakeup.
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-How to "undervolt" AMD RYZEN 5800X3D Guide with PBO2 tuner.
+How to "undervolt" AMD Ryzen 5800X3D guide with PBO2 tuner.
 
-Get the Most out of your 5800X3D using PBO curve optimizer!
+Get the most out of your 5800X3D using PBO curve optimizer!
 
 
 # Table of Contents
 1. [What are we doing?](#1-what-are-we-doing)
-2. [Why are we doing it? What are the Benefits?](#2-why-are-we-doing-it-what-are-the-benefits)
+2. [Why are we doing it? What are the benefits?](#2-why-are-we-doing-it-what-are-the-benefits)
 3. [Options on what we can do](#3-options-on-what-we-can-do)
 4. [What do we need?](#4-what-do-we-need)
 5. [How to set PBO2 Tuner manually](#5-how-to-set-pbo2-tuner-manually)
-6. [How to set PBO2 Tuner automatically with every System boot/restart/wakeup](#6-how-to-set-pbo2-tuner-automatically-with-every-system-bootrestartwakeup)
-7. [(Optional) How to create a custom Alert for every time your PBO2 Tuner settings have been applied automatically](#7-optional-how-to-create-a-custom-alert-for-every-time-your-pbo2-tuner-settings-have-been-applied-automatically)
-8. [What else can we do to improve CPU Clockspeeds and Thermals?](#8-what-else-can-we-do-to-improve-cpu-clockspeeds-and-thermals)
-9.  [Resources used](#9-resources-used)
+6. [How to set PBO2 Tuner automatically with every system boot/restart/wakeup](#6-how-to-set-pbo2-tuner-automatically-with-every-system-bootrestartwakeup)
+7. [(Optional) How to create a custom alert for every time your PBO2 Tuner settings have been applied automatically](#7-optional-how-to-create-a-custom-alert-for-every-time-your-pbo2-tuner-settings-have-been-applied-automatically)
+8. [What else can we do to improve CPU clockspeeds and thermals?](#8-what-else-can-we-do-to-improve-cpu-clockspeeds-and-thermals)
+9. [Resources used](#9-resources-used)
 
 
 # 1) What are we doing? 
-We are using PBO2 Tuner to set a CO curve (PBO 2.0 Curve Optimizer)
+We are using PBO2 Tuner to set a CO curve (PBO 2.0 Curve Optimizer curve)
 
 # 2) Why are we doing it? What are the benefits?
-Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or use PBO in their Bios to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
-With this guide, you will at least be able to tweak things a little inside of Windows for potentially better thermals and clockspeeds that stay longer and more often at the highest they can be.
+Because the 5800X3D is very much locked down on most motherboards thanks to AMD and motherboard manufacturers, most people won't be able to set the boost clock and/or use PBO in their BIOS to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
+With this guide, you will at least be able to tweak things a little inside of Windows (without the need for restarts) for potentially better thermals and clockspeeds that stay longer and more often at the highest they can be.
 
 # 3) Options on what we can do
 Set PBO 2.0 CO curve manually after every change in Windows powerstate
      
 Set PBO 2.0 CO curve automatically with every system boot/restart/wakeup (means after every change in Windows powerstate)
      
-**Optional** possibility to create custom BurnedToast alert whenever the CO curve has been set automatically. This way, you will always have the assurance that it actually applied.
+**Optional** possibility to create a custom BurnedToast alert whenever the CO curve has been set automatically. This way, you will always have the assurance that it actually applied.
     
 # 4) What do we need?
 [Debug-cli.7zp](https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/page-45#post-28999750) from PJVol from Overclocker.net thread
@@ -45,11 +45,11 @@ Any PNG of your choice for the alert
 # 5) How to set PBO2 Tuner manually
 First download [Debug-cli.7zp](https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/page-45#post-28999750).
 
-Get monitoring software like [HwInfo](https://www.hwinfo.com/download/) or [RyzenMaster](https://www.amd.com/en/technologies/ryzen-master). You will need this to see your CPU voltage and temperature and to later confirm that your settings work.
+Get monitoring software like [HWiNFO](https://www.hwinfo.com/download/) or [Ryzen Master](https://www.amd.com/en/technologies/ryzen-master). You will need this to see your CPU voltage and temperature and to later confirm that your settings work.
 
 Run a CPU stress test like OCCT or benchmark like Cinebench R20/R23 to push your CPU to ~100% Utilization. See how high your CPU boosts and what temperatures you get before any changes to it.
 
-Now open PBO2 Tuner.exe from the folder we just downloaded and select the curve tab
+Now open PBO2 Tuner.exe from the folder we just downloaded and select the curve tab.
 
 Start by setting a low negative offset like -10 and decrease it in decrements of -5 to a minimum of -30.
 
@@ -127,7 +127,7 @@ Set-ExecutionPolicy -ExecutionPolicy Unrestricted
 
 into PowerShell and run the command. Press Y to proceed. This is necessary for `Alert.ps1` to work in the future.
 
-**DO THIS AT YOUR OWN RISK**, since you're disabling a security feature of windows.
+**DO THIS AT YOUR OWN RISK**, since you're disabling a security feature of Windows.
 
 Now open Task Scheduler again and look for the task we've created in [Chapter 6](#6-how-to-set-pbo2-tuner-automatically-with-every-system-bootrestartwakeup).
 
@@ -152,7 +152,7 @@ Get a better CPU cooler.
 
 (For enthusiasts with an AIO or custom water cooling block) Get an AM4 cooler offset bracket (like from DerBauer); reportedly around 5-10 degrees improvement on core temps.
 
-Set higher Baseclock (really not recommended if you don't exactly know what it does and what problems can be caused by it)
+Set a higher baseclock (really dangerous if you don't exactly know what it does and what problems can be caused by it)
 # 9) Resources used
 - https://www.overclock.net/threads/corecycler-tool-for-testing-curve-optimizer-settings.1777398/
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Set general settings.
 
 ![Chapter 6 p1_LI](https://user-images.githubusercontent.com/106172193/170519308-df13b85a-00c8-4e57-ad12-6d9b118ed1ac.jpg)
 
-Create the Trigger for login.
-You can set it to Any user but it's safer to set it to trigger on a specific user's login, as in the event of an unstable curve on logging in, you could log in as another user and remove or edit the task.
+Create the Trigger for logon.
+You can set it to Any user but it's safer to set it to trigger on a specific user's logon, as in the event of an unstable curve on logging on, you could log on as another user and remove or edit the task.
 
 ![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/ab62408b-4925-4bbc-a274-dd4c24fdc85f)
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Get the Most out of your 5800X3D using PBO curve optimizer!
 
 
 # 1) What are we doing? 
-We are using PBO2 tuner to set an OC curve (AMD curve optimizer)
+We are using PBO2 Tuner to set a CO curve (PBO 2.0 Curve Optimizer)
 
 # 2) Why are we doing it? What are the Benefits?
 Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or use PBO in their Bios to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
 With this guide, you will at least be able to tweak things a little inside of Windows for potentially better thermals and clockspeeds that stay longer and more often at the highest they can be.
 
 # 3) Options on what we can do
-Set PBO OC curve manually after every change in Windows powerstate
+Set PBO 2.0 CO curve manually after every change in Windows powerstate
      
-Set PBO OC curve automatically with every system boot/restart/wakeup (means after every change in Windows powerstate)
+Set PBO 2.0 CO curve automatically with every system boot/restart/wakeup (means after every change in Windows powerstate)
      
 **Optional** possibility to create custom BurnedToast alert whenever the CO curve has been set automatically. This way, you will always have the assurance that it actually applied.
     

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Create the Trigger for wakeup.
 
 ![Chapter 6 p3](https://user-images.githubusercontent.com/106172193/170519673-90d6766b-6397-4638-a2b8-08c8028839e9.png)
 
-Create the Action for PBO2 tuner.exe to start with the offsets as startup arguments.
+Create the Action for PBO2 tuner.exe to start with the offsets in the field Add arguments.
+Example arguments, if your 5800X3D is as good as mine, would look like this: `-30 -30 -30 -30 -30 -30 -30 -30 0 0 0 0`. The four zeroes at the end are necessary (changing them to non-zero values will decrease performance by limiting clock speeds).
 
 ![Chapter 6 p4_LI](https://user-images.githubusercontent.com/106172193/170519780-4835e046-82fc-49fe-8a9f-e1ded1144638.jpg)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get the Most out of your 5800X3D using PBO curve optimizer!
 # 1) What are we doing? 
 We are using PBO2 Tuner to set a CO curve (PBO 2.0 Curve Optimizer)
 
-# 2) Why are we doing it? What are the Benefits?
+# 2) Why are we doing it? What are the benefits?
 Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or use PBO in their Bios to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
 With this guide, you will at least be able to tweak things a little inside of Windows for potentially better thermals and clockspeeds that stay longer and more often at the highest they can be.
 
@@ -62,7 +62,7 @@ Do all the steps in [Chapter 5](#5-how-to-set-pbo2-tuner-manually) until you're 
 
 Now open Windows Task Scheduler. Go to Actions and Create Task.
 
-**Use the provided Screenshots to configure the Task correctly.**
+**Use the provided Screenshots to configure the task correctly.**
 
 Set general settings.
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Set general settings.
 ![Chapter 6 p1_LI](https://user-images.githubusercontent.com/106172193/170519308-df13b85a-00c8-4e57-ad12-6d9b118ed1ac.jpg)
 
 Create the Trigger for login.
-You can set it to All users but it's safer to set it to trigger on a specific user's login, as in the event of an unstable curve on logging in, you could log in as another user and remove or edit the task.
+You can set it to Any user but it's safer to set it to trigger on a specific user's login, as in the event of an unstable curve on logging in, you could log in as another user and remove or edit the task.
 
-![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/72f25374-a605-4d6a-bc33-3ea56756dd27)
+![Chapter 6 p2](https://github.com/Krzeszny/How-to-undervolt-AMD-RYZEN-5800X3D-Guide-with-PBO2-Tuner/assets/10529134/ab62408b-4925-4bbc-a274-dd4c24fdc85f)
 
 Create the Trigger for wakeup.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Get the Most out of your 5800X3D using PBO curve optimizer!
 We are using PBO2 tuner to set an OC curve (AMD curve optimizer)
 
 # 2) Why are we doing it? What are the Benefits?
-Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or CPU Voltage in their Bios to get the most out of their 5800X3D.
+Because the 5800X3D is very much locked down on most Motherboards thanks to AMD and the Motherboard Manufacturers, most people won't be able to set CPU Ratio and/or use PBO in their Bios to get the most out of their 5800X3D. And if you just apply an offset undervolt, your performance will decrease, not increase, while some motherboards still don't allow using Curve Optimizer on the 5800X3D.
 With this Guide, you will at least be able to tweak Things a little inside of Windows for potentially better Thermals and Clockspeeds that stay longer and more often at the highest they can be.
 
 # 3) Options on what we can do


### PR DESCRIPTION
One part of this commit (sorry, I should've made separate commits, I'm not great with GitHub)  is removing unnecessary capital letters and making tiny punctuation changes.

But the main part is, as the title suggests, replacing the startup trigger. I've found it to _never_ work on startup. However, a logon trigger always works, therefore that's what I'd recommend using in this guide. The logon trigger is so effective that the wakeup trigger is probably unnecessary.

Also, I've added example startup arguments, as that's what I've had problems with when following this guide.